### PR TITLE
fixed PollView bug

### DIFF
--- a/ui/components/PollView.tsx
+++ b/ui/components/PollView.tsx
@@ -47,7 +47,7 @@ function PollView(item) {
       >
         <Box p="2">{item.topic}</Box>
         <Box py="2">{item.choices.map((choice) => choice + ' ')}</Box>
-        {/* <TimeDisplay milliseconds={countdown} /> */}
+        <TimeDisplay milliseconds={countdown} />
       </Grid>
     </Link>
   );

--- a/ui/context/polls.js
+++ b/ui/context/polls.js
@@ -30,7 +30,7 @@ export function PollWrapper ({ children }) {
   }
 
   return (
-    <PollContext.Provider value={{...state, postData}}>
+    <PollContext.Provider value={{ state, postData }}>
       {children}
     </PollContext.Provider>
   )


### PR DESCRIPTION
We were spreading the polls array when we sent it into the context provider so I think it caused an error when we tried to map over individual objects instead of an array of objects